### PR TITLE
Update the README to use syntax highlighting in code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Add `TBAlertController.h` and `TBAlertController.m` to your project and import `
 
 About:
 =============
-`TBAlertController` tries to be as much of a drop-in replacement for the iOS 7 classes as possible, and adds a simpler interface for iOS 8 by allowing you to directly add buttons instead of first creating action objects. This feature is coming soon, however, to remain consitent with `UIAlertController`'s interface.
+`TBAlertController` tries to be as much of a drop-in replacement for the iOS 7 classes as possible, and adds a simpler interface for iOS 8 by allowing you to directly add buttons instead of first creating action objects. This feature is coming soon, however, to remain consistent with `UIAlertController`'s interface.
 
 The only major difference for iOS 7 is that `TBAlertController` does away with delegates in favor of block and target-selector style actions. Delegate support will not be added, since this project is directed at developers who want to minimize code involving action sheets and alert views on iOS 7 and 8. It is possible to use the same code for both platforms; `TBAlertController` takes care of the rest for you.
 
@@ -34,7 +34,9 @@ Actions can be added to any button, either block or target-selector style. Destr
 The target-selector style actions also support passing a single parameter, like `performSelector:withObject:`.
 
 ``` obj-c
-TBAlertController *alert = [[TBAlertController alloc] initWithTitle:@"Title" message:@"Hello world"style:TBAlertControllerStyleActionSheet];
+TBAlertController *alert = [[TBAlertController alloc] initWithTitle:@"Title"
+                                                            message:@"Hello world"
+                                                              style:TBAlertControllerStyleActionSheet];
 [alert addOtherButtonWithTitle:@"Dismiss"];
 [alert addOtherButtonWithTitle:@"Say hi" target:self action:@selector(say:) withObject:@"hi"];
 ```


### PR DESCRIPTION
This PR adds the decoration necessary for GitHub to render code examples with syntax highlighting. It also fixes an issue where code examples were previously indented too far.
